### PR TITLE
Fix post cards missing on homepage

### DIFF
--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -1,0 +1,11 @@
+<div class="post-card">
+  {{ with .Params.categories }}<span class="post-card-category">{{ if reflect.IsSlice . }}{{ index . 0 }}{{ else }}{{ . }}{{ end }}</span>{{ end }}
+  <h2 class="post-card-title">
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  </h2>
+  <p class="post-card-excerpt">{{ .Description | default (.Summary | plainify | truncate 120 "…") }}</p>
+  <div class="post-card-meta">
+    <time>{{ .Date | time.Format "Jan 2, 2006" }}</time>
+    {{ if .ReadingTime }}<span>· {{ .ReadingTime }} min read</span>{{ end }}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Overrode `summary-with-image.html` (used by the homepage) to match the compact post card design already applied to the `/blog/` listing page
- Both homepage and blog listing now show consistent card layout: category, title, 120-char excerpt, date and read time

🤖 Generated with [Claude Code](https://claude.com/claude-code)