### PR TITLE
Fix sticky navbar and redirect homepage to /blog/

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -53,7 +53,7 @@
   </head>
 
   {{- $environment := hugo.Environment | compare.Default "production" -}}
-  <body class="ma0 {{ $.Param "body_classes"  | compare.Default "avenir bg-near-white"}} {{ $environment }}">
+  <body class="ma0 {{ $.Param "body_classes"  | compare.Default "avenir bg-near-white"}} {{ $environment }}{{ if .IsPage }} is-single{{ end }}">
     {{ if .IsPage }}<div id="reading-progress"></div>{{ end }}
 
     {{ block "header" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/blog/">
+  <link rel="canonical" href="/blog/">
+</head>
+<body>
+  <a href="/blog/">Redirecting to blog…</a>
+</body>
+</html>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -218,14 +218,9 @@ section.flex-ns.mt5 > div {
 
 /* ── Navigation ── */
 nav[role="navigation"] {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background: #fff;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   border-bottom: 1px solid #e8e8e8;
-  box-shadow: 0 1px 6px rgba(0,0,0,0.06);
 }
 
 nav a.f3 img {
@@ -327,10 +322,20 @@ nav ul a:hover {
   }
 }
 
-/* Prevent header wrapper from blocking sticky nav */
-body > header,
-body > div > header {
-  position: relative;
+/* Fixed navbar on single post pages only */
+body.is-single > header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: #fff;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+}
+
+/* Push content down to account for fixed navbar on post pages */
+body.is-single {
+  padding-top: 64px;
 }
 
 /* ── Footer ── */


### PR DESCRIPTION
## Summary
- Navbar is now fixed on single post pages only (`body.is-single > header`) — doesn't affect list/home pages
- `layouts/index.html` added to redirect `/` → `/blog/` so there's one canonical URL for the post listing
- `body.is-single` gets `padding-top: 64px` so content doesn't hide under the fixed nav

## Test plan
- [ ] Scroll down a blog post — navbar stays fixed at top
- [ ] Visit `/` — redirects instantly to `/blog/`
- [ ] Visit `/blog/` — listing renders normally, no title overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)