### PR TITLE
Fix sticky navbar on all pages including blog listing

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,37 +1,26 @@
 {{ $featured_image := partials.Include "func/GetFeaturedImage.html" . }}
 {{ if $featured_image }}
-  {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
   {{ $featured_image_class := site.Params.featured_image_class | compare.Default "cover bg-top" }}
   <header class="{{ $featured_image_class }}" style="background-image: url('{{ $featured_image }}');">
     {{ $cover_dimming_class := site.Params.cover_dimming_class | compare.Default "bg-black-60" }}
     <div class="{{ $cover_dimming_class }}">
-      {{ partials.Include "site-navigation.html" .}}
-      <div class="tc-l pv4 pv6-l ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
-          {{ .Title | compare.Default .Site.Title }}
-        </h1>
-        {{ with .Params.description }}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
-            {{ . }}
-          </h2>
-        {{ end }}
-      </div>
+      {{ partials.Include "site-navigation.html" . }}
     </div>
   </header>
+  <div class="section-hero tc-l pv4 pv6-l ph3 ph4-ns">
+    <h1 class="f2 f-subheadline-l fw2 mb0 lh-title" style="color:#333;">{{ .Title | compare.Default .Site.Title }}</h1>
+    {{ with .Params.description }}<h2 class="fw1 f5 f3-l measure-wide-l center lh-copy mt3 mb4" style="color:#555;">{{ . }}</h2>{{ end }}
+  </div>
 {{ else }}
   <header>
-    <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | compare.Default "bg-black" }}">
+    <div class="bg-white">
       {{ partials.Include "site-navigation.html" . }}
-      <div class="tc-l pv3 ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
-          {{ .Title | compare.Default .Site.Title }}
-        </h1>
-        {{ with .Params.description }}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
-            {{ . }}
-          </h2>
-        {{ end }}
-      </div>
     </div>
   </header>
+  {{ if not .IsHome }}
+  <div class="section-hero tc-l pv3 ph3 ph4-ns">
+    <h1 class="f2 fw2 light-silver mb0 lh-title">{{ .Title | compare.Default .Site.Title }}</h1>
+    {{ with .Params.description }}<h2 class="fw1 f5 measure-wide-l center lh-copy mt3 mb4 mid-gray">{{ . }}</h2>{{ end }}
+  </div>
+  {{ end }}
 {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -322,8 +322,8 @@ nav ul a:hover {
   }
 }
 
-/* Fixed navbar on single post pages only */
-body.is-single > header {
+/* Fixed navbar on all pages */
+body > header {
   position: fixed;
   top: 0;
   left: 0;
@@ -333,8 +333,8 @@ body.is-single > header {
   box-shadow: 0 1px 6px rgba(0,0,0,0.06);
 }
 
-/* Push content down to account for fixed navbar on post pages */
-body.is-single {
+/* Push all content down to account for fixed navbar */
+body {
   padding-top: 64px;
 }
 


### PR DESCRIPTION
## Summary
- Overrode `site-header.html` to keep only the nav inside `<header>` — section title moved outside so it scrolls normally
- Fixed navbar now applies to all pages (was previously only on single post pages)
- Global `body { padding-top: 64px }` prevents content from hiding under the fixed nav

## Test plan
- [ ] Scroll down `/blog/` — navbar stays fixed, "Blogs" title scrolls away
- [ ] Scroll down a post — navbar stays fixed
- [ ] No content hidden behind navbar on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)