### PR TITLE
Add search functionality with Pagefind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 # Stage 1: Build Hugo site
 FROM hugomods/hugo:debian-nightly AS builder
 
+RUN apt-get update && apt-get install -y nodejs npm && npm install -g pagefind
+
 WORKDIR /src
 COPY . .
-RUN hugo --minify
+RUN hugo --minify && pagefind --site public
 
 # Stage 2: Serve with Nginx
 FROM nginx:alpine

--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,5 @@
+---
+title: "Search"
+layout: "search"
+description: "Search posts"
+---

--- a/content/search.md
+++ b/content/search.md
@@ -1,5 +1,4 @@
 ---
 title: "Search"
 layout: "search"
-description: "Search posts"
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -60,7 +60,7 @@
       {{ partials.Include "site-header.html" . }}
     {{ end }}
     <div class="content-container">
-    {{ if .IsPage }}<a href="{{ .CurrentSection.RelPermalink }}" class="back-link">All posts</a>{{ end }}
+    {{ if and .IsPage (ne .Layout "search") }}<a href="{{ .CurrentSection.RelPermalink }}" class="back-link">All posts</a>{{ end }}
     <!-- Main content -->
     <main class="main-content" style="width: 100%;">
       {{ block "main" . }}{{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,20 +1,106 @@
 {{ define "main" }}
 <div class="search-page">
-  <h1 class="search-page-title">Search</h1>
-  <div id="search"></div>
+  <div class="search-hero">
+    <h1 class="search-hero-title">Search posts</h1>
+    <div class="search-input-wrap">
+      <svg class="search-input-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+      </svg>
+      <input
+        id="search-input"
+        class="search-input"
+        type="search"
+        placeholder="Search articles…"
+        autofocus
+        autocomplete="off"
+      />
+      <button id="search-clear" class="search-clear" aria-label="Clear" style="display:none">✕</button>
+    </div>
+  </div>
+
+  <div id="search-results" class="search-results"></div>
+  <div id="search-empty" class="search-empty" style="display:none">
+    <p>No results for <strong id="search-empty-query"></strong></p>
+    <p class="search-empty-hint">Try a different keyword or check the spelling.</p>
+  </div>
+  <div id="search-idle" class="search-idle">
+    <p>Start typing to search across all posts.</p>
+  </div>
 </div>
 
-<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/pagefind/pagefind-ui.js"></script>
 <script>
-  window.addEventListener('DOMContentLoaded', function() {
-    new PagefindUI({
-      element: '#search',
-      showSubResults: true,
-      showImages: false,
-      excerptLength: 20,
-      resetStyles: false
+(async function() {
+  await import('/pagefind/pagefind.js').then(async (pf) => {
+    const pagefind = pf;
+    await pagefind.init();
+
+    const input    = document.getElementById('search-input');
+    const results  = document.getElementById('search-results');
+    const empty    = document.getElementById('search-empty');
+    const idle     = document.getElementById('search-idle');
+    const clearBtn = document.getElementById('search-clear');
+    const emptyQ   = document.getElementById('search-empty-query');
+
+    let debounce;
+
+    input.addEventListener('input', () => {
+      clearTimeout(debounce);
+      debounce = setTimeout(() => runSearch(input.value.trim()), 200);
+      clearBtn.style.display = input.value ? 'flex' : 'none';
     });
+
+    clearBtn.addEventListener('click', () => {
+      input.value = '';
+      clearBtn.style.display = 'none';
+      results.innerHTML = '';
+      empty.style.display = 'none';
+      idle.style.display = '';
+      input.focus();
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('q')) {
+      input.value = params.get('q');
+      clearBtn.style.display = 'flex';
+      runSearch(params.get('q'));
+    }
+
+    async function runSearch(query) {
+      if (!query) {
+        results.innerHTML = '';
+        empty.style.display = 'none';
+        idle.style.display = '';
+        return;
+      }
+      idle.style.display = 'none';
+
+      const search = await pagefind.search(query);
+
+      if (!search.results.length) {
+        results.innerHTML = '';
+        emptyQ.textContent = query;
+        empty.style.display = '';
+        return;
+      }
+
+      empty.style.display = 'none';
+
+      const cards = await Promise.all(search.results.slice(0, 10).map(async (r) => {
+        const data = await r.data();
+        return `
+          <a href="${data.url}" class="search-result-card">
+            <div class="search-result-meta">${data.meta?.date ?? ''}</div>
+            <h2 class="search-result-title">${data.meta?.title ?? data.url}</h2>
+            <p class="search-result-excerpt">${data.excerpt}</p>
+          </a>`;
+      }));
+
+      results.innerHTML = cards.join('');
+    }
+  }).catch(() => {
+    document.getElementById('search-idle').innerHTML =
+      '<p class="search-idle-warn">Search index not available. Run <code>pagefind --site public</code> after building.</p>';
   });
+})();
 </script>
 {{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<div class="search-page">
+  <h1 class="search-page-title">Search</h1>
+  <div id="search"></div>
+</div>
+
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-ui.js"></script>
+<script>
+  window.addEventListener('DOMContentLoaded', function() {
+    new PagefindUI({
+      element: '#search',
+      showSubResults: true,
+      showImages: false,
+      excerptLength: 20,
+      resetStyles: false
+    });
+  });
+</script>
+{{ end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+<a href="/blog/" class="back-link">All posts</a>
 <div class="search-page">
   <div class="search-hero">
     <div class="search-input-wrap">

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,7 +1,6 @@
 {{ define "main" }}
 <div class="search-page">
   <div class="search-hero">
-    <h1 class="search-hero-title">Search posts</h1>
     <div class="search-input-wrap">
       <svg class="search-input-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -17,7 +17,7 @@
       {{ partials.Include "site-navigation.html" . }}
     </div>
   </header>
-  {{ if not .IsHome }}
+  {{ if and (not .IsHome) (ne .Layout "search") }}
   <div class="section-hero tc-l pv3 ph3 ph4-ns">
     <h1 class="f2 fw2 light-silver mb0 lh-title">{{ .Title | compare.Default .Site.Title }}</h1>
     {{ with .Params.description }}<h2 class="fw1 f5 measure-wide-l center lh-copy mt3 mb4 mid-gray">{{ . }}</h2>{{ end }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -21,6 +21,11 @@
         </ul>
       {{ end }}
       {{ partials.IncludeCached "social/follow.html" . }}
+      <a href="/search/" class="nav-search-btn" aria-label="Search">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+      </a>
     </div>
   </div>
 </nav>

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -21,11 +21,11 @@
         </ul>
       {{ end }}
       {{ partials.IncludeCached "social/follow.html" . }}
-      <a href="/search/" class="nav-search-btn" aria-label="Search">
+      {{ if ne .Layout "search" }}<a href="/search/" class="nav-search-btn" aria-label="Search">
         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
         </svg>
-      </a>
+      </a>{{ end }}
     </div>
   </div>
 </nav>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -338,6 +338,72 @@ body {
   padding-top: 64px;
 }
 
+/* ── Search icon in navbar ── */
+.nav-search-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 1rem;
+  color: #1C1C1E;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.nav-search-btn:hover {
+  color: #3b6af5;
+}
+
+/* ── Search page ── */
+.search-page {
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.search-page-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #111;
+}
+
+/* Pagefind UI overrides */
+.pagefind-ui__search-input {
+  border: 1px solid #e0e0e0 !important;
+  border-radius: 8px !important;
+  font-size: 1rem !important;
+  padding: 0.75rem 1rem !important;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05) !important;
+}
+
+.pagefind-ui__search-input:focus {
+  border-color: #3b6af5 !important;
+  outline: none !important;
+  box-shadow: 0 0 0 3px rgba(59,106,245,0.15) !important;
+}
+
+.pagefind-ui__result {
+  border-bottom: 1px solid #f0f0f0 !important;
+  padding: 1.25rem 0 !important;
+}
+
+.pagefind-ui__result-title {
+  font-size: 1rem !important;
+  font-weight: 600 !important;
+  color: #111 !important;
+}
+
+.pagefind-ui__result-link {
+  color: #3b6af5 !important;
+  text-decoration: none !important;
+}
+
+.pagefind-ui__result-excerpt {
+  font-size: 0.875rem !important;
+  color: #555 !important;
+  line-height: 1.6 !important;
+}
+
 /* ── Footer ── */
 footer[role="contentinfo"] {
   font-size: 0.85rem;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,8 +1,24 @@
 /* ── Layout ── */
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+body > header {
+  flex-shrink: 0;
+}
+
 .content-container {
+  flex: 1;
   max-width: 860px;
   margin: 0 auto;
   padding: 0 1.5rem 3rem;
+  width: 100%;
 }
 
 .main-content {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -355,53 +355,144 @@ body {
 
 /* ── Search page ── */
 .search-page {
-  max-width: 720px;
-  margin: 2rem auto;
-  padding: 0 1rem;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
 }
 
-.search-page-title {
+.search-hero {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.search-hero-title {
   font-size: 1.75rem;
-  font-weight: 600;
-  margin-bottom: 1.5rem;
+  font-weight: 700;
   color: #111;
+  margin-bottom: 1.25rem;
 }
 
-/* Pagefind UI overrides */
-.pagefind-ui__search-input {
-  border: 1px solid #e0e0e0 !important;
-  border-radius: 8px !important;
-  font-size: 1rem !important;
-  padding: 0.75rem 1rem !important;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.05) !important;
+.search-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
-.pagefind-ui__search-input:focus {
-  border-color: #3b6af5 !important;
-  outline: none !important;
-  box-shadow: 0 0 0 3px rgba(59,106,245,0.15) !important;
+.search-input-icon {
+  position: absolute;
+  left: 1rem;
+  color: #999;
+  pointer-events: none;
 }
 
-.pagefind-ui__result {
-  border-bottom: 1px solid #f0f0f0 !important;
-  padding: 1.25rem 0 !important;
+.search-input {
+  width: 100%;
+  padding: 0.85rem 3rem 0.85rem 2.75rem;
+  font-size: 1rem;
+  border: 1.5px solid #e0e0e0;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  background: #fff;
+  color: #111;
+  font-family: inherit;
 }
 
-.pagefind-ui__result-title {
-  font-size: 1rem !important;
-  font-weight: 600 !important;
-  color: #111 !important;
+.search-input:focus {
+  border-color: #3b6af5;
+  box-shadow: 0 0 0 3px rgba(59,106,245,0.12);
 }
 
-.pagefind-ui__result-link {
-  color: #3b6af5 !important;
-  text-decoration: none !important;
+.search-clear {
+  position: absolute;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #999;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  padding: 0.25rem;
+  border-radius: 4px;
+  transition: color 0.15s;
 }
 
-.pagefind-ui__result-excerpt {
-  font-size: 0.875rem !important;
-  color: #555 !important;
-  line-height: 1.6 !important;
+.search-clear:hover { color: #333; }
+
+.search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.search-result-card {
+  display: block;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid #e8e8e8;
+  border-radius: 10px;
+  background: #fff;
+  text-decoration: none;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  transition: box-shadow 0.2s, transform 0.2s;
+}
+
+.search-result-card:hover {
+  box-shadow: 0 4px 14px rgba(0,0,0,0.09);
+  transform: translateY(-2px);
+}
+
+.search-result-meta {
+  font-size: 0.72rem;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.3rem;
+}
+
+.search-result-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111;
+  margin: 0 0 0.4rem;
+  line-height: 1.4;
+}
+
+.search-result-card:hover .search-result-title {
+  color: #3b6af5;
+}
+
+.search-result-excerpt {
+  font-size: 0.875rem;
+  color: #555;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.search-result-excerpt mark {
+  background: #fff3c4;
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+.search-empty,
+.search-idle {
+  text-align: center;
+  padding: 2rem 0;
+  color: #888;
+  font-size: 0.95rem;
+}
+
+.search-empty strong { color: #333; }
+.search-empty-hint { font-size: 0.85rem; margin-top: 0.5rem; }
+.search-idle-warn { color: #c0392b; }
+.search-idle-warn code {
+  background: #f5f5f5;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
 }
 
 /* ── Footer ── */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -223,6 +223,18 @@ nav[role="navigation"] {
   border-bottom: 1px solid #e8e8e8;
 }
 
+/* Force flex row on all screen sizes — theme uses flex-l (large only) */
+nav[role="navigation"] > div {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+}
+
+nav[role="navigation"] > div > div {
+  display: flex !important;
+  align-items: center;
+}
+
 nav a.f3 img {
   height: 36px;
   width: auto;


### PR DESCRIPTION
## Summary
- Adds static site search using Pagefind (post-build indexing)
- Custom search page at `/search/` with clean card-style results
- Search icon in navbar (hidden on search page itself)
- Back to all posts link on search page
- Sticky footer fix and mobile nav alignment fixes
- Dockerfile updated to run pagefind after hugo build

## Test plan
- [ ] Build site and run `pagefind --site public`, then verify search works
- [ ] Search icon in navbar links to `/search/`
- [ ] Search icon hidden when on the search page
- [ ] Back to all posts link visible on search page
- [ ] Mobile navbar aligned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)