### PR TITLE
Floating back button and clickable post cards

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -59,7 +59,12 @@
     {{ block "header" . }}
       {{ partials.Include "site-header.html" . }}
     {{ end }}
-    {{ if and .IsPage (ne .Layout "search") }}<a href="{{ .CurrentSection.RelPermalink }}" class="back-link">← All posts</a>{{ end }}
+    {{ if and .IsPage (ne .Layout "search") }}
+    <a href="{{ .CurrentSection.RelPermalink }}" class="back-fab" aria-label="All posts">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+      <span class="back-fab-label">All posts</span>
+    </a>
+    {{ end }}
     <div class="content-container">
     <!-- Main content -->
     <main class="main-content" style="width: 100%;">

--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -1,11 +1,9 @@
-<div class="post-card">
+<a href="{{ .RelPermalink }}" class="post-card">
   {{ with .Params.categories }}<span class="post-card-category">{{ if reflect.IsSlice . }}{{ index . 0 }}{{ else }}{{ . }}{{ end }}</span>{{ end }}
-  <h2 class="post-card-title">
-    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-  </h2>
+  <h2 class="post-card-title">{{ .Title }}</h2>
   <p class="post-card-excerpt">{{ .Description | default (.Summary | plainify | truncate 120 "…") }}</p>
   <div class="post-card-meta">
     <time>{{ .Date | time.Format "Jan 2, 2006" }}</time>
     {{ if .ReadingTime }}<span>· {{ .ReadingTime }} min read</span>{{ end }}
   </div>
-</div>
+</a>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,11 +1,9 @@
-<div class="post-card">
+<a href="{{ .RelPermalink }}" class="post-card">
   {{ with .Params.categories }}<span class="post-card-category">{{ if reflect.IsSlice . }}{{ index . 0 }}{{ else }}{{ . }}{{ end }}</span>{{ end }}
-  <h2 class="post-card-title">
-    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-  </h2>
+  <h2 class="post-card-title">{{ .Title }}</h2>
   <p class="post-card-excerpt">{{ .Description | default (.Summary | plainify | truncate 120 "…") }}</p>
   <div class="post-card-meta">
     <time>{{ .Date | time.Format "Jan 2, 2006" }}</time>
     {{ if .ReadingTime }}<span>· {{ .ReadingTime }} min read</span>{{ end }}
   </div>
-</div>
+</a>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -179,17 +179,22 @@ a.ba.b--moon-gray:hover {
 
 /* ── Post list cards ── */
 .post-card {
+  display: flex;
+  flex-direction: column;
   padding: 1.25rem 1.5rem;
   border-radius: 8px;
   border: 1px solid #e8e8e8;
   background: #fff;
   box-shadow: 0 1px 4px rgba(0,0,0,0.05);
-  transition: box-shadow 0.2s, transform 0.2s;
+  transition: box-shadow 0.25s, transform 0.25s;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 
 .post-card:hover {
-  box-shadow: 0 4px 14px rgba(0,0,0,0.09);
-  transform: translateY(-2px);
+  box-shadow: 0 8px 28px rgba(0,0,0,0.12);
+  transform: translateY(-6px);
 }
 
 .post-card-category {
@@ -206,12 +211,7 @@ a.ba.b--moon-gray:hover {
   line-height: 1.35;
 }
 
-.post-card-title a {
-  color: #111;
-  text-decoration: none;
-}
-
-.post-card-title a:hover {
+.post-card:hover .post-card-title {
   color: #3b6af5;
 }
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -302,28 +302,46 @@ nav ul a:hover {
 }
 
 /* ── Back link on post pages ── */
-.back-link {
+/* ── Floating back button on post pages ── */
+.back-fab {
+  position: fixed;
+  left: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 999;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #444;
+  gap: 0;
+  background: #fff;
+  color: #333;
   text-decoration: none;
-  padding: 0.45rem 1.5rem;
-  background: #f2f2f2;
-  border-bottom: 1px solid #e0e0e0;
-  position: fixed;
-  top: 61px;
-  left: 0;
-  right: 0;
-  z-index: 999;
-  transition: color 0.15s, background 0.15s;
+  border-radius: 999px;
+  padding: 0.65rem;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.15);
+  transition: gap 0.2s ease, padding 0.2s ease, color 0.15s, box-shadow 0.2s;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.back-link:hover {
+.back-fab:hover {
   color: #3b6af5;
-  background: #e8eeff;
+  padding: 0.65rem 1.1rem;
+  gap: 0.4rem;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.18);
+}
+
+.back-fab-label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-width 0.2s ease, opacity 0.2s ease;
+}
+
+.back-fab:hover .back-fab-label {
+  max-width: 120px;
+  opacity: 1;
 }
 
 /* ── Author sidebar ── */
@@ -394,10 +412,6 @@ body {
   padding-top: 64px;
 }
 
-/* Post pages have navbar + back bar, need extra offset */
-body.is-single {
-  padding-top: 103px;
-}
 
 /* ── Search icon in navbar ── */
 .nav-search-btn {


### PR DESCRIPTION
## Summary
- Replaced fixed back bar with a floating circular pill button on the left side of post pages — expands to show 'All posts' on hover
- Made entire post card clickable (wrapped in anchor tag)
- Stronger hover lift effect on post cards (translateY -6px with deeper shadow)
- Title turns blue on card hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)